### PR TITLE
Add "pipeline_flags" for configuring the pipeline runner.

### DIFF
--- a/moonlight/pipeline/BUILD
+++ b/moonlight/pipeline/BUILD
@@ -1,0 +1,17 @@
+# Description:
+# OMR pipelines and Apache Beam utilities.
+package(
+    default_visibility = ["//moonlight:__subpackages__"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+py_library(
+    name = "pipeline_flags",
+    srcs = ["pipeline_flags.py"],
+    deps = [
+        # absl dep
+        # apache-beam dep
+    ],
+    srcs_version = "PY2ONLY",
+)

--- a/moonlight/pipeline/pipeline_flags.py
+++ b/moonlight/pipeline/pipeline_flags.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Configures the Apache Beam runner from the command line in pipelines.
+
+Command-line flags for particular runners can be added here later, if necessary.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl import flags
+import apache_beam
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    'runner', 'DirectRunner',
+    'The class name of the Apache Beam runner to use in the pipeline.')
+
+
+def create_pipeline(**kwargs):
+  return apache_beam.Pipeline(FLAGS.runner, **kwargs)

--- a/moonlight/training/clustering/BUILD
+++ b/moonlight/training/clustering/BUILD
@@ -43,6 +43,7 @@ py_binary(
     srcs_version = "PY2AND3",
     deps = [
         ":staffline_patches_dofn",
+        "//moonlight/pipeline:pipeline_flags",
         # absl dep
         # apache-beam dep
         # tensorflow dep

--- a/moonlight/training/clustering/staffline_patches_kmeans_pipeline.py
+++ b/moonlight/training/clustering/staffline_patches_kmeans_pipeline.py
@@ -29,12 +29,12 @@ import tempfile
 from absl import flags
 import apache_beam as beam
 from apache_beam.transforms import combiners
+from moonlight.pipeline import pipeline_flags
+from moonlight.training.clustering import staffline_patches_dofn
 import tensorflow as tf
 from tensorflow.contrib.learn.python.learn import learn_runner
 from tensorflow.python.lib.io import file_io
 from tensorflow.python.lib.io import tf_record
-
-from moonlight.training.clustering import staffline_patches_dofn
 
 FLAGS = flags.FLAGS
 
@@ -145,7 +145,7 @@ def main(_):
   records_dir = tempfile.mkdtemp(prefix='staffline_kmeans')
   try:
     patch_file_prefix = os.path.join(records_dir, 'patches')
-    with beam.Pipeline() as pipeline:
+    with pipeline_flags.create_pipeline() as pipeline:
       filenames = file_io.get_matching_files(FLAGS.music_pattern)
       assert filenames, 'Must have matched some filenames'
       if 0 < FLAGS.num_pages < len(filenames):


### PR DESCRIPTION
This should be used for constructing the Pipeline object so that the
runner can be set on the command line. This will also allow us to add
command-line flags for particular runners later, if necessary.