### PR TITLE
Add REST_THIRTYSECOND.

### DIFF
--- a/moonlight/protobuf/groundtruth.proto
+++ b/moonlight/protobuf/groundtruth.proto
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 syntax = "proto2";
 
 package tensorflow.moonlight;

--- a/moonlight/protobuf/musicscore.proto
+++ b/moonlight/protobuf/musicscore.proto
@@ -1,3 +1,16 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 syntax = "proto2";
 
 package tensorflow.moonlight;
@@ -116,11 +129,15 @@ message Glyph {
     REST_QUARTER = 7;
     REST_EIGHTH = 8;
     REST_SIXTEENTH = 9;
+    // TODO(ringw): Sixty-fourth rests don't fit within our typical patch
+    // size (3 times the staffline distance), so they can't be detected under
+    // the current model.
+    REST_THIRTYSECOND = 17;
     FLAT = 10;
     SHARP = 11;
     DOUBLE_SHARP = 16;
     NATURAL = 12;
-    // Next tag: 17
+    // Next tag: 18
   }
 }
 


### PR DESCRIPTION
This fits neatly in the current patch size, but sixty-fourth rests will
be too tall, and it's unclear how to handle them.

Add the missing license notice to the proto files.