### PR TITLE
Travis CI: Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,10 @@ before_install:
   - sha256sum -c tools/bazel_0.12.0-linux-x86_64.deb.sha256
   - sudo dpkg -i bazel_0.12.0-linux-x86_64.deb
 
+before_script:
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+
 script:
   - tools/travis_tests.sh


### PR DESCRIPTION
Use flake8 to stop the build if there are Python syntax errors or undefined names.

__xrange()__ was removed from Python 3 in favor of __range()__.