### PR TITLE
Replace a TODO with an explanatory comment.

### DIFF
--- a/moonlight/models/base/hyperparameters.py
+++ b/moonlight/models/base/hyperparameters.py
@@ -68,11 +68,10 @@ def estimator_with_saved_params(estimator, params):
       for name, value in six.iteritems(params):
         tf.add_to_collection('params', tf.constant(name=name, value=value))
 
-    # TODO(ringw): Some estimators may want the params. However, we currently
-    # only use the DNNClassifier estimator, which does not use the params in its
-    # model_fn. Therefore, we only pass the params into the model at all in
-    # order to encode them here, and they are otherwise only used outside of the
-    # model_fn when constructing the estimator.
+    # The Estimator model_fn property always returns a wrapped "public"
+    # model_fn. The public wrapper doesn't take "params", and passes the params
+    # from the Estimator constructor into the internal model_fn. Therefore, it
+    # only matters that we pass the params to the Estimator below.
     return estimator.model_fn(features, labels, mode, config)
 
   return tf.estimator.Estimator(

--- a/moonlight/models/glyphs_dnn/model.py
+++ b/moonlight/models/glyphs_dnn/model.py
@@ -64,15 +64,30 @@ def get_flag_params():
     # logistic regression (no hidden dims).
     layer_dims = []
   return {
-      'model_name': 'glyphs_dnn',
-      'layer_dims': layer_dims,
-      'activation_fn': FLAGS.activation_fn,
-      'learning_rate': FLAGS.learning_rate,
-      'l1_regularization_strength': FLAGS.l1_regularization_strength,
-      'l2_regularization_strength': FLAGS.l2_regularization_strength,
-      'dropout': FLAGS.dropout,
-      'none_label_weight': FLAGS.none_label_weight,
-      'use_included_label_weight': FLAGS.use_included_label_weight,
+      'model_name':
+          'glyphs_dnn',
+      'layer_dims':
+          layer_dims,
+      'activation_fn':
+          FLAGS.activation_fn,
+      'learning_rate':
+          FLAGS.learning_rate,
+      'l1_regularization_strength':
+          FLAGS.l1_regularization_strength,
+      'l2_regularization_strength':
+          FLAGS.l2_regularization_strength,
+      'dropout':
+          FLAGS.dropout,
+      'none_label_weight':
+          FLAGS.none_label_weight,
+      'use_included_label_weight':
+          FLAGS.use_included_label_weight,
+
+      # Declared in glyph_patches.py.
+      'augmentation_x_shift_probability':
+          FLAGS.augmentation_x_shift_probability,
+      'augmentation_max_rotation_degrees':
+          FLAGS.augmentation_max_rotation_degrees,
   }
 
 


### PR DESCRIPTION
"Estimator.model_fn" always returns a wrapped callable that doesn't take
a "params" argument. This isn't specific to DNNClassifier, so this
utility is already robust to other types of estimators.