### PR TITLE
Support reading the run min length from a constant in the saved model.

### DIFF
--- a/moonlight/glyphs/convolutional.py
+++ b/moonlight/glyphs/convolutional.py
@@ -30,11 +30,13 @@ import tensorflow as tf
 from moonlight.glyphs import base
 from moonlight.protobuf import musicscore_pb2
 
+DEFAULT_RUN_MIN_LENGTH = 3
+
 
 class Convolutional1DGlyphClassifier(base.BaseGlyphClassifier):
   """The base 1D convolutional glyph classifier model."""
 
-  def __init__(self, run_min_length=3):
+  def __init__(self, run_min_length=DEFAULT_RUN_MIN_LENGTH):
     """Base classifier model.
 
     Args:

--- a/moonlight/glyphs/saved_classifier_test.py
+++ b/moonlight/glyphs/saved_classifier_test.py
@@ -25,6 +25,7 @@ import tensorflow as tf
 
 from moonlight import image
 from moonlight import structure
+from moonlight.glyphs import convolutional
 from moonlight.glyphs import saved_classifier
 from moonlight.protobuf import musicscore_pb2
 
@@ -61,6 +62,9 @@ class SavedClassifierTest(tf.test.TestCase):
         page = image.decode_music_score_png(tf.read_file(filename))
         clazz = saved_classifier.SavedConvolutional1DClassifier(
             structure.create_structure(page), export_dir)
+        # Run min length should be the default.
+        self.assertEqual(
+            clazz.run_min_length, convolutional.DEFAULT_RUN_MIN_LENGTH)
         predictions = clazz.staffline_predictions.eval()
         self.assertEqual(predictions.ndim, 3)  # Staff, staff position, x
         self.assertGreater(predictions.size, 0)


### PR DESCRIPTION
This will allow setting this runtime parameter on a per-model basis, to
tweak the model performance. If the model is very sensitive to x
coordinate, we might need to decrease run_min_length so that a shorter
run of consecutive patches can result in a glyph. Otherwise, we might
need to increase run_min_length to decrease false positives.

In a follow-up, will add a command-line tool for writing this type of
constant to an existing saved model.