### PR TITLE
Add precision and recall metrics for a subset of classes.

### DIFF
--- a/moonlight/models/base/BUILD
+++ b/moonlight/models/base/BUILD
@@ -35,6 +35,7 @@ py_library(
         ":batches",
         ":label_weights",
         # absl dep
+        "//moonlight/protobuf:protobuf_py_pb2",
         "//moonlight/util:memoize",
         # tensorflow dep
     ],

--- a/moonlight/models/base/glyph_patches_test.py
+++ b/moonlight/models/base/glyph_patches_test.py
@@ -79,6 +79,38 @@ class GlyphPatchesTest(tf.test.TestCase):
            [4, 4, 5, 6],
            [8, 8, 9, 10]])
 
+  def testMulticlassBinaryMetric(self):
+    # pyformat: disable
+    # pylint: disable=bad-whitespace
+    labels =                     tf.constant([1, 1, 3, 2, 2, 2, 2])
+    predictions = dict(class_ids=tf.constant([1, 3, 2, 2, 4, 3, 2]))
+    _, precision_1 = glyph_patches.multiclass_binary_metric(
+        1, tf.metrics.precision, labels, predictions)
+    _, recall_1 = glyph_patches.multiclass_binary_metric(
+        1, tf.metrics.recall, labels, predictions)
+    _, precision_2 = glyph_patches.multiclass_binary_metric(
+        2, tf.metrics.precision, labels, predictions)
+    _, recall_2 = glyph_patches.multiclass_binary_metric(
+        2, tf.metrics.recall, labels, predictions)
+    _, precision_3 = glyph_patches.multiclass_binary_metric(
+        3, tf.metrics.precision, labels, predictions)
+    _, recall_3 = glyph_patches.multiclass_binary_metric(
+        3, tf.metrics.recall, labels, predictions)
+
+    with self.test_session() as sess:
+      sess.run(tf.local_variables_initializer())
+      # For class 1: 1 true positive and no false positives
+      self.assertEqual(1.0, precision_1.eval())
+      # For class 1: 1 true positive and 1 false negative
+      self.assertEqual(0.5, recall_1.eval())
+      # For class 2: 2 true positives and 1 false positive
+      self.assertAlmostEqual(2 / 3, precision_2.eval(), places=5)
+      # For class 2: 2 true positives and 2 false negatives
+      self.assertEqual(0.5, recall_2.eval())
+      # For class 3: No true positives
+      self.assertEqual(0, precision_3.eval())
+      self.assertEqual(0, recall_3.eval())
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/moonlight/models/glyphs_dnn/model.py
+++ b/moonlight/models/glyphs_dnn/model.py
@@ -39,19 +39,6 @@ flags.DEFINE_float('l2_regularization_strength', 0, 'L2 penalty')
 flags.DEFINE_float('dropout', 0, 'Dropout to apply to all hidden nodes.')
 
 
-def _custom_metrics(features, labels, predictions):
-  """Metrics to be computed on every evaluation run, viewable in TensorBoard."""
-  del features  # Unused.
-  return {
-      'mean_per_class_accuracy':
-      tf.metrics.mean_per_class_accuracy(
-          labels=labels,
-          predictions=predictions['class_ids'][:, 0],
-          num_classes=len(musicscore_pb2.Glyph.Type.keys()),
-      ),
-  }
-
-
 def get_flag_params():
   """Returns the hyperparameters specified by flags.
 
@@ -123,6 +110,4 @@ def create_estimator(params=None):
       dropout=FLAGS.dropout,
       model_dir=glyph_patches.FLAGS.model_dir,
   )
-  return hyperparameters.estimator_with_saved_params(
-      tf.contrib.estimator.add_metrics(estimator, _custom_metrics),
-      params)
+  return hyperparameters.estimator_with_saved_params(estimator, params)


### PR DESCRIPTION
Move metrics from glyphs_dnn to base/glyph_patches.py, since they are
not neural network-specific.