### PR TITLE
Support a floating-point staffline distance multiple.

### DIFF
--- a/moonlight/staves/staffline_extractor.py
+++ b/moonlight/staves/staffline_extractor.py
@@ -210,7 +210,10 @@ class StafflineExtractor(object):
         tf.int32)
 
   def _get_staffline_window_size(self, staffline_distance):
-    return staffline_distance * self.staffline_distance_multiple
+    return tf.to_int32(
+        tf.round(
+            tf.to_float(staffline_distance) * tf.to_float(
+                self.staffline_distance_multiple)))
 
 
 class StafflinePatchExtractor(object):

--- a/moonlight/staves/staffline_extractor_test.py
+++ b/moonlight/staves/staffline_extractor_test.py
@@ -26,31 +26,69 @@ from moonlight.staves import staffline_extractor
 
 class StafflineExtractorTest(tf.test.TestCase):
 
-  def testExtractStaff(self):
+  def setUp(self):
     # Small image with a single staff.
-    image = np.asarray([[1, 1, 1, 1, 1, 1, 1], [1, 0, 0, 0, 0, 0, 1],
-                        [1, 1, 0, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0, 1],
-                        [1, 0, 0, 0, 0, 0, 1], [1, 1, 1, 1, 1, 1, 1],
-                        [1, 1, 1, 1, 1, 1, 1], [1, 0, 0, 0, 0, 0, 1],
-                        [1, 0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1],
-                        [1, 0, 0, 0, 0, 0, 1], [1, 1, 1, 1, 1, 1, 1],
-                        [1, 1, 1, 1, 1, 1, 1], [1, 0, 0, 0, 0, 0, 1]],
-                       np.uint8) * 255
-    image_t = tf.constant(image, name='image')
+    # pyformat: disable
+    self.single_staff_image = np.asarray(
+        [[1, 1, 1, 1, 1, 1, 1],
+         [1, 0, 0, 0, 0, 0, 1],
+         [1, 1, 0, 1, 1, 1, 1],
+         [1, 1, 1, 1, 0, 0, 1],
+         [1, 0, 0, 0, 0, 0, 1],
+         [1, 1, 1, 1, 1, 1, 1],
+         [1, 1, 1, 1, 1, 1, 1],
+         [1, 0, 0, 0, 0, 0, 1],
+         [1, 0, 1, 1, 1, 1, 1],
+         [1, 1, 1, 1, 1, 1, 1],
+         [1, 0, 0, 0, 0, 0, 1],
+         [1, 1, 1, 1, 1, 1, 1],
+         [1, 1, 1, 1, 1, 1, 1],
+         [1, 0, 0, 0, 0, 0, 1]], np.uint8) * 255
+
+  def testExtractStaff(self):
+    image_t = tf.constant(self.single_staff_image, name='image')
     detector = staves.ProjectionStaffDetector(image_t)
     # The staffline distance is 3, so use a target height of 6 to avoid scaling
     # the image.
     extractor = staffline_extractor.StafflineExtractor(
-        image_t, detector, target_height=6, num_sections=9,
+        image_t,
+        detector,
+        target_height=6,
+        num_sections=9,
         staffline_distance_multiple=2)
     with self.test_session():
       stafflines = extractor.extract_staves().eval()
     assert stafflines.shape == (1, 9, 6, 7)
     # The top staff line is at a y-value of 2 because of rounding.
-    assert np.array_equal(stafflines[0, 0],
-                          np.concatenate((np.zeros((2, 7)), image[:4] / 255.0)))
+    assert np.array_equal(
+        stafflines[0, 0],
+        np.concatenate((np.zeros((2, 7)), self.single_staff_image[:4] / 255.0)))
     # The staff space is centered in the window.
-    assert np.array_equal(stafflines[0, 3], image[3:9] / 255.0)
+    assert np.array_equal(stafflines[0, 3],
+                          self.single_staff_image[3:9] / 255.0)
+    # Staffline height is 3 and extracted strips have 2 staff line distances
+    # with a total height of 6, so the strip is not actually scaled.
+    self.assertTrue(
+        np.logical_or(np.isclose(stafflines, 1.), np.isclose(stafflines,
+                                                             0.)).all())
+
+  def testFloatMultiple(self):
+    image_t = tf.constant(self.single_staff_image, name='image')
+    detector = staves.ProjectionStaffDetector(image_t)
+    extractor = staffline_extractor.StafflineExtractor(
+        image_t,
+        detector,
+        target_height=6,
+        num_sections=9,
+        staffline_distance_multiple=1.5)
+    with self.test_session():
+      stafflines = extractor.extract_staves().eval()
+    # Staff strip is scaled up because the input height is less. Some output
+    # pixels have aliasing.
+    self.assertAllEqual(stafflines.shape, (1, 9, 6, 10))
+    self.assertFalse(
+        np.logical_or(np.isclose(stafflines, 1.), np.isclose(stafflines,
+                                                             0.)).all())
 
 
 class StafflinePatchExtractorTest(tf.test.TestCase):


### PR DESCRIPTION
This could be useful for tuning the patch size for the classifier.